### PR TITLE
Deduplicate dmp

### DIFF
--- a/xcm-emulator/example/src/lib.rs
+++ b/xcm-emulator/example/src/lib.rs
@@ -305,116 +305,80 @@ mod tests {
 	#[test]
 	fn deduplicate_dmp() {
 		Network::reset();
-
-		let remark = yayoi::Call::System(frame_system::Call::<yayoi::Runtime>::remark_with_event {
-			remark: "Hello from Kusama!".as_bytes().to_vec(),
-		});
-		let remark2 = yayoi::Call::System(frame_system::Call::<yayoi::Runtime>::remark_with_event {
-			remark: "Hello from Polkadot!".as_bytes().to_vec(),
-		});
-
 		KusamaNet::execute_with(|| {
 			assert_ok!(kusama_runtime::XcmPallet::force_default_xcm_version(
 				kusama_runtime::Origin::root(),
 				Some(0)
 			));
-			assert_ok!(kusama_runtime::XcmPallet::send_xcm(
-				Here,
-				Parachain(1),
-				Xcm(vec![Transact {
-					origin_type: OriginKind::SovereignAccount,
-					require_weight_at_most: INITIAL_BALANCE as u64,
-					call: remark.encode().into(),
-				}]),
-			));
-			// second same dmp mesage in one relay-parent-block wouldn't execution
-			assert_ok!(kusama_runtime::XcmPallet::send_xcm(
-				Here,
-				Parachain(1),
-				Xcm(vec![Transact {
-					origin_type: OriginKind::SovereignAccount,
-					require_weight_at_most: INITIAL_BALANCE as u64,
-					call: remark.encode().into(),
-				}]),
-			));
 		});
-		YayoiPumpkin::execute_with(|| {
-			use yayoi::{Event, System};
-			System::events().iter().for_each(|r| println!(">>> {:?}", r.event));
 
-			assert!(System::events().iter().any(|r| matches!(
-				r.event,
-				Event::System(frame_system::Event::Remarked { sender: _, hash: _ })
-			)));
-
-			System::reset_events();
-		});
+		kusama_send_rmrk("Kusama", 2);
+		parachain_receive_and_reset_events(true);
 
 		// a different dmp message in same relay-parent-block allow execution.
-		KusamaNet::execute_with(|| {
-			assert_ok!(kusama_runtime::XcmPallet::send_xcm(
-				Here,
-				Parachain(1),
-				Xcm(vec![Transact {
-					origin_type: OriginKind::SovereignAccount,
-					require_weight_at_most: INITIAL_BALANCE as u64,
-					call: remark2.encode().into(),
-				}]),
-			));
-		});
-		YayoiPumpkin::execute_with(|| {
-			use yayoi::{Event, System};
-			assert!(System::events().iter().any(|r| matches!(
-				r.event,
-				Event::System(frame_system::Event::Remarked { sender: _, hash: _ })
-			)));
+		kusama_send_rmrk("Polkadot", 1);
+		parachain_receive_and_reset_events(true);
 
-			System::reset_events();
-		});
-
-		// same dmp message in another tx but with same relay-parent-block wouldn't
-		// execution
-		KusamaNet::execute_with(|| {
-			assert_ok!(kusama_runtime::XcmPallet::send_xcm(
-				Here,
-				Parachain(1),
-				Xcm(vec![Transact {
-					origin_type: OriginKind::SovereignAccount,
-					require_weight_at_most: INITIAL_BALANCE as u64,
-					call: remark.encode().into(),
-				}]),
-			));
-		});
-		YayoiPumpkin::execute_with(|| {
-			use yayoi::{Event, System};
-			assert!(System::events().iter().all(|r| !matches!(
-				r.event,
-				Event::System(frame_system::Event::Remarked { sender: _, hash: _ })
-			)));
-		});
+		// same dmp message with same relay-parent-block wouldn't execution
+		kusama_send_rmrk("Kusama", 1);
+		parachain_receive_and_reset_events(false);
 
 		// different relay-parent-block allow dmp message execution
 		KusamaNet::execute_with(|| kusama_runtime::System::set_block_number(2));
 
+		kusama_send_rmrk("Kusama", 1);
+		parachain_receive_and_reset_events(true);
+
+		// reset can send same dmp message again
+		Network::reset();
 		KusamaNet::execute_with(|| {
-			assert_ok!(kusama_runtime::XcmPallet::send_xcm(
-				Here,
-				Parachain(1),
-				Xcm(vec![Transact {
-					origin_type: OriginKind::SovereignAccount,
-					require_weight_at_most: INITIAL_BALANCE as u64,
-					call: remark.encode().into(),
-				}]),
+			assert_ok!(kusama_runtime::XcmPallet::force_default_xcm_version(
+				kusama_runtime::Origin::root(),
+				Some(0)
 			));
 		});
+
+		kusama_send_rmrk("Kusama", 1);
+		parachain_receive_and_reset_events(true);
+	}
+
+	fn kusama_send_rmrk(msg: &str, count: u32) {
+		let remark = yayoi::Call::System(frame_system::Call::<yayoi::Runtime>::remark_with_event {
+			remark: msg.as_bytes().to_vec(),
+		});
+		KusamaNet::execute_with(|| {
+			for _ in 0..count {
+				assert_ok!(kusama_runtime::XcmPallet::send_xcm(
+					Here,
+					Parachain(1),
+					Xcm(vec![Transact {
+						origin_type: OriginKind::SovereignAccount,
+						require_weight_at_most: INITIAL_BALANCE as u64,
+						call: remark.encode().into(),
+					}]),
+				));
+			}
+		});
+	}
+
+	fn parachain_receive_and_reset_events(received: bool) {
 		YayoiPumpkin::execute_with(|| {
 			use yayoi::{Event, System};
 			System::events().iter().for_each(|r| println!(">>> {:?}", r.event));
 
-			assert!(System::events().iter().any(|r| matches!(
-				r.event,
-				Event::System(frame_system::Event::Remarked { sender: _, hash: _ })
-			)));
+			if received {
+				assert!(System::events().iter().any(|r| matches!(
+					r.event,
+					Event::System(frame_system::Event::Remarked { sender: _, hash: _ })
+				)));
+
+				System::reset_events();
+			} else {
+				assert!(System::events().iter().all(|r| !matches!(
+					r.event,
+					Event::System(frame_system::Event::Remarked { sender: _, hash: _ })
+				)));
+			}
 		});
 	}
 }

--- a/xcm-emulator/example/src/lib.rs
+++ b/xcm-emulator/example/src/lib.rs
@@ -301,4 +301,120 @@ mod tests {
 				.any(|r| matches!(r.event, Event::XcmpQueue(cumulus_pallet_xcmp_queue::Event::Fail(_, _)))));
 		});
 	}
+
+	#[test]
+	fn deduplicate_dmp() {
+		Network::reset();
+
+		let remark = yayoi::Call::System(frame_system::Call::<yayoi::Runtime>::remark_with_event {
+			remark: "Hello from Kusama!".as_bytes().to_vec(),
+		});
+		let remark2 = yayoi::Call::System(frame_system::Call::<yayoi::Runtime>::remark_with_event {
+			remark: "Hello from Polkadot!".as_bytes().to_vec(),
+		});
+
+		KusamaNet::execute_with(|| {
+			assert_ok!(kusama_runtime::XcmPallet::force_default_xcm_version(
+				kusama_runtime::Origin::root(),
+				Some(0)
+			));
+			assert_ok!(kusama_runtime::XcmPallet::send_xcm(
+				Here,
+				Parachain(1),
+				Xcm(vec![Transact {
+					origin_type: OriginKind::SovereignAccount,
+					require_weight_at_most: INITIAL_BALANCE as u64,
+					call: remark.encode().into(),
+				}]),
+			));
+			// second same dmp mesage in one relay-parent-block wouldn't execution
+			assert_ok!(kusama_runtime::XcmPallet::send_xcm(
+				Here,
+				Parachain(1),
+				Xcm(vec![Transact {
+					origin_type: OriginKind::SovereignAccount,
+					require_weight_at_most: INITIAL_BALANCE as u64,
+					call: remark.encode().into(),
+				}]),
+			));
+		});
+		YayoiPumpkin::execute_with(|| {
+			use yayoi::{Event, System};
+			System::events().iter().for_each(|r| println!(">>> {:?}", r.event));
+
+			assert!(System::events().iter().any(|r| matches!(
+				r.event,
+				Event::System(frame_system::Event::Remarked { sender: _, hash: _ })
+			)));
+
+			System::reset_events();
+		});
+
+		// a different dmp message in same relay-parent-block allow execution.
+		KusamaNet::execute_with(|| {
+			assert_ok!(kusama_runtime::XcmPallet::send_xcm(
+				Here,
+				Parachain(1),
+				Xcm(vec![Transact {
+					origin_type: OriginKind::SovereignAccount,
+					require_weight_at_most: INITIAL_BALANCE as u64,
+					call: remark2.encode().into(),
+				}]),
+			));
+		});
+		YayoiPumpkin::execute_with(|| {
+			use yayoi::{Event, System};
+			assert!(System::events().iter().any(|r| matches!(
+				r.event,
+				Event::System(frame_system::Event::Remarked { sender: _, hash: _ })
+			)));
+
+			System::reset_events();
+		});
+
+		// same dmp message in another tx but with same relay-parent-block wouldn't
+		// execution
+		KusamaNet::execute_with(|| {
+			assert_ok!(kusama_runtime::XcmPallet::send_xcm(
+				Here,
+				Parachain(1),
+				Xcm(vec![Transact {
+					origin_type: OriginKind::SovereignAccount,
+					require_weight_at_most: INITIAL_BALANCE as u64,
+					call: remark.encode().into(),
+				}]),
+			));
+		});
+		YayoiPumpkin::execute_with(|| {
+			use yayoi::{Event, System};
+			assert!(System::events().iter().all(|r| !matches!(
+				r.event,
+				Event::System(frame_system::Event::Remarked { sender: _, hash: _ })
+			)));
+		});
+
+		// different relay-parent-block allow dmp message execution
+		KusamaNet::execute_with(|| kusama_runtime::System::set_block_number(2));
+
+		KusamaNet::execute_with(|| {
+			assert_ok!(kusama_runtime::XcmPallet::send_xcm(
+				Here,
+				Parachain(1),
+				Xcm(vec![Transact {
+					origin_type: OriginKind::SovereignAccount,
+					require_weight_at_most: INITIAL_BALANCE as u64,
+					call: remark.encode().into(),
+				}]),
+			));
+		});
+		YayoiPumpkin::execute_with(|| {
+			use yayoi::{Event, System};
+			System::events().iter().for_each(|r| println!(">>> {:?}", r.event));
+
+			assert!(System::events().iter().any(|r| matches!(
+				r.event,
+				Event::System(frame_system::Event::Remarked { sender: _, hash: _ })
+			)));
+		});
+	}
 }

--- a/xcm-emulator/src/lib.rs
+++ b/xcm-emulator/src/lib.rs
@@ -347,7 +347,6 @@ macro_rules! decl_test_network {
 							if msgs.len() != 0 {
 								<$parachain>::handle_dmp_messages(msgs.clone().into_iter(), $crate::Weight::max_value());
 								for m in msgs {
-									// println!("done: {}: {}, {:?}", to_para_id, m.0, m.1.clone());
 									$crate::DMP_DONE.with(|b| b.borrow_mut().push_back((to_para_id, m.0, m.1)));
 								}
 							}

--- a/xcm-emulator/src/lib.rs
+++ b/xcm-emulator/src/lib.rs
@@ -273,8 +273,8 @@ thread_local! {
 	pub static DOWNWARD_MESSAGES: RefCell<VecDeque<(u32, Vec<(RelayBlockNumber, Vec<u8>)>)>>
 		= RefCell::new(VecDeque::new());
 		#[allow(clippy::type_complexity)]
-	/// Downwarded messages that was sent to parachains, each message is: `(to_para_id, relay_block_number)`
-	pub static DOWNWARDED_MESSAGES: RefCell<VecDeque<(u32, RelayBlockNumber)>>
+	/// Downwarded messages that was sent to parachains, each message is: `(to_para_id, relay_block_number, Vec<u8>)`
+	pub static DOWNWARDED_MESSAGES: RefCell<VecDeque<(u32, RelayBlockNumber, Vec<u8>)>>
 		= RefCell::new(VecDeque::new());
 	/// Horizontal messages, each message is: `(to_para_id, [(from_para_id, relay_block_number, msg)])`
 	#[allow(clippy::type_complexity)]
@@ -333,11 +333,11 @@ macro_rules! decl_test_network {
 						$para_id => {
 							let msg_clone = messages.clone();
 							let msgs = messages.into_iter().filter(|m| {
-								!$crate::DOWNWARDED_MESSAGES.with(|b| b.borrow_mut().contains(&(to_para_id, m.0)))
+								!$crate::DOWNWARDED_MESSAGES.with(|b| b.borrow_mut().contains(&(to_para_id, m.0, m.1.clone())))
 							});
 							<$parachain>::handle_dmp_messages(msgs, $crate::Weight::max_value());
 							for m in msg_clone {
-								$crate::DOWNWARDED_MESSAGES.with(|b| b.borrow_mut().push_back((to_para_id, m.0)));
+								$crate::DOWNWARDED_MESSAGES.with(|b| b.borrow_mut().push_back((to_para_id, m.0, m.1)));
 							}
 						},
 					)*

--- a/xcm-emulator/src/lib.rs
+++ b/xcm-emulator/src/lib.rs
@@ -296,12 +296,15 @@ macro_rules! decl_test_network {
 
 		impl $name {
 			pub fn reset() {
-				use $crate::TestExt;
+				use $crate::{TestExt, VecDeque};
 
 				<$relay_chain>::reset_ext();
 				$( <$parachain>::reset_ext(); )*
 
 				$( <$parachain>::prepare_for_xcmp(); )*
+
+				$crate::DOWNWARD_MESSAGES.with(|b| b.replace(VecDeque::new()));
+				$crate::DOWNWARDED_MESSAGES.with(|b| b.replace(VecDeque::new()));
 			}
 		}
 


### PR DESCRIPTION
when testing https://github.com/AcalaNetwork/Acala/pull/1712 which send two xcm, recipient parachain get two dmp messages from relaychain. this is because `dmp_contents` not deleted, thus causing duplicate mssages.

the deduplicate condition is based on `to_para_id`,`relay_block_number` and `msg`, this means relaychain can only send one same msg to one parachain in one block. it may make sense in testcase.