### PR TITLE
fix: prevent infinite dmp recursion

### DIFF
--- a/xcm-emulator/src/lib.rs
+++ b/xcm-emulator/src/lib.rs
@@ -358,10 +358,10 @@ macro_rules! decl_test_network {
 								!$crate::DMP_DONE.with(|b| b.borrow_mut().contains(&(to_para_id, m.0, m.1.clone())))
 							}).collect::<Vec<(RelayChainBlockNumber, Vec<u8>)>>();
 							if msgs.len() != 0 {
-								<$parachain>::handle_dmp_messages(msgs.clone().into_iter(), $crate::Weight::max_value());
-								for m in msgs {
+								for m in msgs.clone() {
 									$crate::DMP_DONE.with(|b| b.borrow_mut().push_back((to_para_id, m.0, m.1)));
 								}
+								<$parachain>::handle_dmp_messages(msgs.into_iter(), $crate::Weight::max_value());
 							}
 						},
 					)*


### PR DESCRIPTION
Without this fix, I got a stackoverflow when trying to send this message from the relay chain to the parachain:
```
[
        ReserveAssetDeposited((Parent, 1000000000000u128).into()),
        BuyExecution {
            fees: (Parent, 100000000000u128).into(),
            weight_limit: Unlimited,
        },
        QueryPallet {
            module_name: "frame_system".into(), response_info: QueryResponseInfo {
                destination: Parent.into(),
                query_id: 1,
                max_weight:Weight::from_ref_time(10000000000000000u64)
            }
        }
]
```

The stacktrace that I got was (slightly abbreviated):
```
kusama_test_net::_process_downward_messages (xcm-simulator-ce151af85e435b6b/754f3b9/xcm-emulator/src/lib.rs:361)
kusama_test_net::_process_messages (xcm-simulator-ce151af85e435b6b/754f3b9/xcm-emulator/src/lib.rs:332)
<kusama_test_net::KusamaNet as xcm_emulator::TestExt>::execute_with (xcm-simulator-ce151af85e435b6b/754f3b9/xcm-emulator/src/lib.rs:157)
<kusama_test_net::KusamaNet as polkadot_runtime_parachains::ump::UmpSink>::process_upward_message (xcm-simulator-ce151af85e435b6b/754f3b9/xcm-emulator/src/lib.rs:59)
kusama_test_net::_process_upward_messages (xcm-simulator-ce151af85e435b6b/754f3b9/xcm-emulator/src/lib.rs:393)
kusama_test_net::_process_messages (xcm-simulator-ce151af85e435b6b/754f3b9/xcm-emulator/src/lib.rs:330)
<kusama_test_net::Kintsugi as xcm_emulator::TestExt>::execute_with (xcm-simulator-ce151af85e435b6b/754f3b9/xcm-emulator/src/lib.rs:273)
<kusama_test_net::Kintsugi as polkadot_parachain::primitives::DmpMessageHandler>::handle_dmp_messages (xcm-simulator-ce151af85e435b6b/754f3b9/xcm-emulator/src/lib.rs:102)

kusama_test_net::_process_downward_messages (xcm-simulator-ce151af85e435b6b/754f3b9/xcm-emulator/src/lib.rs:361)
kusama_test_net::_process_messages (xcm-simulator-ce151af85e435b6b/754f3b9/xcm-emulator/src/lib.rs:332)
<kusama_test_net::KusamaNet as xcm_emulator::TestExt>::execute_with (xcm-simulator-ce151af85e435b6b/754f3b9/xcm-emulator/src/lib.rs:157)
<kusama_test_net::KusamaNet as polkadot_runtime_parachains::ump::UmpSink>::process_upward_message (xcm-simulator-ce151af85e435b6b/754f3b9/xcm-emulator/src/lib.rs:59)
kusama_test_net::_process_upward_messages (xcm-simulator-ce151af85e435b6b/754f3b9/xcm-emulator/src/lib.rs:393)
kusama_test_net::_process_messages (xcm-simulator-ce151af85e435b6b/754f3b9/xcm-emulator/src/lib.rs:330)
<kusama_test_net::Kintsugi as xcm_emulator::TestExt>::execute_with (xcm-simulator-ce151af85e435b6b/754f3b9/xcm-emulator/src/lib.rs:273)
<kusama_test_net::Kintsugi as polkadot_parachain::primitives::DmpMessageHandler>::handle_dmp_messages (xcm-simulator-ce151af85e435b6b/754f3b9/xcm-emulator/src/lib.rs:102)

<repeat>
```